### PR TITLE
feat: Uncurve derivatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## _unreleased_
+
+### Changed
+
+- Теперь колонки `avgNT`, `delNT` в таблице `computed.NTDerivatives` содержат
+  вертикальный ПЭС $N_T$
+  ([#22](https://github.com/mixayloff-dimaaylov/logserver-spark/pull/22))
+
+### Added
+
+- Добавлен расчет вертикального ПЭС $N_T$
+  ([#22](https://github.com/mixayloff-dimaaylov/logserver-spark/pull/22))
+
+### Fixed
+
+### Removed
+
 ## [0.3.0] - 2023-04-29
 
 ### Changed


### PR DESCRIPTION
## Summary

Добавляет поддержку расчета вертикального среднего ПЭС $\overline{N_T}$ и
вертикальных флуктуаций ПЭС $\Delta N_T$.

## Details

Расчет вертикального ПЭС $N_T$ позволяет переходить к другим спутниковым
системам и строить "тепловые" карты. Переход к вертикальному ПЭС до применения
фильтров не возможен в текущей версии Spark, т.к. `INNER JOIN` с _watermark_
нарушает порядок следования элементов до применения цифровых фильтров. По этой
причине вертикальные значения вычисляются на выходе каждого цифрового фильтра.

Для работы требуется, чтобы лог `SATXYZ2` имел частоту дискретизации $f_{д}$,
равную 60 Гц, так же, как и значения цифровых фильтров.

Поддержка расчета наклонных ПЭС $N_T$ ($\overline{N_{T (\phi) s}}$,
$\Delta N_{T (\phi) s}$ в новой нотации) оставлена в отладочных целях, однако,
все последующие показатели рассчитываются из вертикального ПЭС.

## Breaking changes

- Теперь колонки `avgNT`, `delNT` в таблице `computed.NTDerivatives` содержат
  вертикальный ПЭС $N_T$