### PR TITLE
feat!: Add string GeoHash columns for GeoMap plugin

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/StreamFunctions.scala
+++ b/src/main/scala/com/infocom/examples/spark/StreamFunctions.scala
@@ -146,6 +146,8 @@ class StreamFunctions(
     Array(Math.toDegrees(lat), Math.toDegrees(lon % (2 * Math.PI)), alt)
   }
 
+  /*GeoPoint*/
+
   def satGeoPoint(xyz: DataPointSatxyz2): Long = {
     satGeoPoint(xyz.X, xyz.Y, xyz.Z)
   }
@@ -156,6 +158,18 @@ class StreamFunctions(
     GeoHash.withBitPrecision(lla(0), lla(1), 52).longValueLeft
   }
 
+  def satGeoPointStr(xyz: DataPointSatxyz2): String = {
+    satGeoPointStr(xyz.X, xyz.Y, xyz.Z)
+  }
+
+  def satGeoPointStr(X: Double, Y: Double, Z: Double): String = {
+    val lla = ecef2lla(Array(X, Y, Z))
+
+    GeoHash.withCharacterPrecision(lla(0), lla(1), 12).toBase32
+  }
+
+  /*IonPoint*/
+
   def satIonPoint(xyz: DataPointSatxyz2): Long = {
     satIonPoint(xyz.X, xyz.Y, xyz.Z)
   }
@@ -165,6 +179,17 @@ class StreamFunctions(
     val lla = ecef2lla(intersection(point, get_unit_vector(get_vector(point, receiver))))
 
     GeoHash.withBitPrecision(lla(0), lla(1), 52).longValueLeft
+  }
+
+  def satIonPointStr(xyz: DataPointSatxyz2): String = {
+    satIonPointStr(xyz.X, xyz.Y, xyz.Z)
+  }
+
+  def satIonPointStr(X: Double, Y: Double, Z: Double): String = {
+    val point = Array(X, Y, Z)
+    val lla = ecef2lla(intersection(point, get_unit_vector(get_vector(point, receiver))))
+
+    GeoHash.withCharacterPrecision(lla(0), lla(1), 12).toBase32
   }
 
   def satElevation(xyz: DataPointSatxyz2): Double = {

--- a/src/main/scala/com/infocom/examples/spark/TecCalculationV2.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculationV2.scala
@@ -206,23 +206,20 @@ object TecCalculationV2 extends Serializable {
     /* Definitions */
     val sf = new StreamFunctions(recLat, recLon, recAlt)
 
-    def satGeoPoint: UserDefinedFunction = udf {
-      (X: Double, Y: Double, Z: Double) => {
-        sf.satGeoPoint(X, Y, Z)
-      } : Long
-    }
+    def satGeoPoint: UserDefinedFunction
+      = udf[Long, Double, Double, Double](sf.satGeoPoint _)
 
-    def satIonPoint: UserDefinedFunction = udf {
-      (X: Double, Y: Double, Z: Double) => {
-        sf.satIonPoint(X, Y, Z)
-      } : Long
-    }
+    def satGeoPointStr: UserDefinedFunction
+      = udf[String, Double, Double, Double](sf.satGeoPointStr _)
 
-    def satElevation: UserDefinedFunction = udf {
-      (X: Double, Y: Double, Z: Double) => {
-        sf.satElevation(X, Y, Z)
-      } : Double
-    }
+    def satIonPoint: UserDefinedFunction
+      = udf[Long, Double, Double, Double](sf.satIonPoint _)
+
+    def satIonPointStr: UserDefinedFunction
+      = udf[String, Double, Double, Double](sf.satIonPointStr _)
+
+    def satElevation: UserDefinedFunction
+      = udf[Double, Double, Double, Double](sf.satElevation _)
 
     val kafkaServerAddress = args(3)
     val clickHouseServerAddress = args(4)
@@ -357,7 +354,9 @@ object TecCalculationV2 extends Serializable {
         .select(
           $"point.Timestamp".as("time"),
           satGeoPoint($"point.X", $"point.Y", $"point.Z").as("geopoint"),
+          satGeoPointStr($"point.X", $"point.Y", $"point.Z").as("geopointStr"),
           satIonPoint($"point.X", $"point.Y", $"point.Z").as("ionpoint"),
+          satIonPointStr($"point.X", $"point.Y", $"point.Z").as("ionpointStr"),
           satElevation($"point.X", $"point.Y", $"point.Z").as("elevation"),
           $"point.Satellite".as("sat"),
           $"point.NavigationSystem".as("system"),


### PR DESCRIPTION
## Summary

Добавлено вычисление поля со строковым GeoHash для плагина Grafana
GeoMap. Текущий используемый Int-GeoHash не поддерживается ни плагином GeoMap,
ни ClickHouse.

## Details

Используемые Int-GeoHash, по всей видимости, не распространен. Строковый GeoHash
поддерживается разработчиками Grafana, ClickHouse и прочих утилит. Поддержка
желательна.

Для обратной совместимости с `satmap-panel` поддержка Int-GeoHash будет
сохранена.

## Breaking changes

- Добавлены столбцы в таблицу `rawdata.satxyz2`